### PR TITLE
試著把東西更新到 Python 3.6 + Django 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## 學習前準備
 在使用這份指南前，請先準備好：
 
-1. [安裝 Python 3.5](http://djangogirlstaipei.herokuapp.com/tutorials/installation/)
-2. [註冊 PythonAnywhere](https://www.pythonanywhere.com/)
+1. [安裝 Python 3.5 或 3.6](http://djangogirlstaipei.herokuapp.com/tutorials/installation/)
+2. [註冊 PythonAnywhere](http://djangogirlstaipei.herokuapp.com/tutorials/setting-up-pythonanywhere/)
 
 
 ## 學習範例

--- a/django/admin.md
+++ b/django/admin.md
@@ -2,7 +2,7 @@
 
 大部份網站都設計有管理後台，讓管理者方便新增或異動網站內容。
 
-而這樣的管理後台，Django 也有內建一個 App -- [**Django Admin**](https://docs.djangoproject.com/en/1.8/ref/contrib/admin/) 。只需要稍微設定，網站就能擁有管理後台功能。
+而這樣的管理後台，Django 也有內建一個 App — [**Django Admin**](https://docs.djangoproject.com/en/1.11/ref/contrib/admin/) 。只需要稍微設定，網站就能擁有管理後台功能。
 
 前一章，我們學到如何使用 Django Model 抽象地表達資料庫結構。現在，我們要透過 **Django Admin** 看到實際的資料，並跟資料庫進行互動。
 
@@ -21,29 +21,29 @@
 ```
 # mysite/settings.py
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     ...
-)
+]
 ```
 
 當你在同步資料庫時，也會建立需要的資料表及欄位。
 
 ### 設定管理後台的 URL
 
-為了讓你可以從瀏覽器進入管理後台，我們需要設定對應的 urls 。
+為了讓你可以從瀏覽器進入管理後台，我們需要設定對應的 URL patterns。
 
 我們將管理後台的網址設定為 `/admin/`。確認 `mysite/urls.py` 中的 `urlpatterns` 包含下面這行：
 
 ```
-url(r'^admin/', include(admin.site.urls)),
+url(r'^admin/', admin.site.urls),
 ```
 
 ## 建立 superuser
 
 要使用 Django 的管理後台，需要一個管理員帳號。
 
-使用 [createsuperuser](https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-createsuperuser) 這個指令，建立一個 superuser：
+使用 [createsuperuser](https://docs.djangoproject.com/en/1.11/ref/django-admin/#django-admin-createsuperuser) 這個指令，建立一個 superuser：
 
 ```
 (djangogirls_venv) ~/djangogirls/mysite$ python manage.py createsuperuser
@@ -61,7 +61,7 @@ Superuser created successfully.
 
 最後，我們需要在讓 Django 知道，有哪些 Model 需要管理後台。
 
-修改 **trips app** 裡的 admin.py，並註冊 **Post** 這個 Model：
+修改 **trips** app 裡的 `admin.py`，並註冊 **Post** 這個 model：
 
 ```python
 # trips/admin.py
@@ -71,7 +71,6 @@ from .models import Post
 
 
 admin.site.register(Post)
-
 ```
 
 ## 使用管理後台
@@ -101,7 +100,7 @@ admin.site.register(Post)
 
 ---
 
-Django 通常以 `Post object` 來表示 Post 物件，但此種顯示不易辨別。我們可以透過 [`def __str__`](https://docs.djangoproject.com/en/1.8/ref/models/instances/#str)  更改 Post 的表示方式。
+Django 通常以 `Post object` 來表示 Post 物件，但此種顯示不易辨別。我們可以透過 [`def __str__`](https://docs.djangoproject.com/en/1.11/ref/models/instances/#str)  更改 Post 的表示方式。
 
 修改 `trips/models.py`：
 

--- a/django/deploy.md
+++ b/django/deploy.md
@@ -4,8 +4,31 @@
 
 我們選擇 [PythonAnywhere](https://www.PythonAnywhere.com/) 作為範例。它對於 Python 的支援性相當好，免費帳號也足夠經營一個小型網站。
 
+在開始部署之前，請先確定已經根據[課前準備](https://djangogirlstaipei.herokuapp.com/tutorials/setting-up-pythonanywhere/)，在 [PythonAnywhere](https://www.PythonAnywhere.com/) 註冊帳號：
 
-## 部署準備
+![](./../images/PythonAnywhere-signup.png)
+
+
+## 修改設定
+
+打開 `settings.py`，找到下面這行：
+
+```python
+ALLOWED_HOSTS = []
+```
+
+這段設定是用來控制你的網站可以用哪些網址連線。我們之前都是用 `127.0.0.1` 或 `localhost`，代表本機連線，所以不需要指定，但當我們把網站放到雲端，就不能再用這個網址。
+
+我們把 PythonAnywhere 的網址加入這個設定。在預設狀況下，這個網址會是 <https://你的帳號.pythonanywhere.com>，所以假設你的 PythonAnywhere username 是 `djangogirls`，就請把這個設定改成
+
+```python
+ALLOWED_HOSTS = ['djangogirls.pythonanywhere.com']
+```
+
+再提醒一次，記得要將 `djangogirls` 改成你在 PythonAnywhere 註冊的 *username*。
+
+
+## 打包程式碼
 
 為了將你的程式碼上傳到雲端，我們要先將整個專案打包成一個壓縮檔。在 `djangogirls` 專案目錄下，用以下的指令將整個專案壓縮成 `mysite.zip`：
 
@@ -13,12 +36,8 @@
 (djangogirls_venv) ~/djangogirls$ python -m zipfile -c mysite.zip mysite
 ```
 
+
 ## 部署到雲端
-
-在開始部署之前，請先確定已經在 [PythonAnywhere](https://www.PythonAnywhere.com/) 註冊帳號：
-
-![](./../images/PythonAnywhere-signup.png)
-
 
 ### Step 1: 上傳專案
 
@@ -36,6 +55,8 @@
 
 ![](./../images/PythonAnywhere-consoles.png)
 
+#### Step 2.1: 解壓縮專案
+
 首先利用 `unzip` 指令將專案解壓縮：
 
 ```
@@ -44,12 +65,14 @@
 
 ![](./../images/PythonAnywhere-bash.png)
 
+#### Step 2.2: 建立虛擬環境、安裝 Django
+
 由於雲端的環境與我們本機端不同，我們需要為它建立一個新的虛擬環境，並在裡面安裝 Django：
 
 ```
-~ $ virtualenv --python=python3.5 djangogirls_venv
+~ $ virtualenv --python=python3.6 djangogirls_venv
 ~ $ source djangogirls_venv/bin/activate
-(djangogirls_venv) ~ $ pip install "django<1.9"
+(djangogirls_venv) ~ $ pip install "django<1.12"
 ```
 
 
@@ -67,7 +90,7 @@
 
 ![](./../images/PythonAnywhere-new-web-2.png)
 
-在 Python 版本選擇畫面中使用 *Python 3.5*。
+在 Python 版本選擇畫面中使用 *Python 3.6*。
 
 ![](./../images/PythonAnywhere-new-web-3.png)
 
@@ -130,10 +153,11 @@ application = StaticFilesHandler(get_wsgi_application())
 
 ---
 
-未來如果對網站進行任何修改，可以使用以下的步驟更新：
+未來如果對網站進行任何修改，只要重複以下的章節，就可以更新程式：
 
-1. 壓縮專案、上傳
-2. 用 Bash console 解壓縮
+1. 打包程式碼
+2. 上傳專案
+2. 開啟 Bash console，解壓縮專案
 3. 重新載入（Reload）web app
 
 就可以在 PythonAnywhere 上看到新的程式。

--- a/django/dynamic_url.md
+++ b/django/dynamic_url.md
@@ -25,7 +25,7 @@ from .models import Post
 def post_detail(request, pk):
     post = Post.objects.get(pk=pk)
     return render(request, 'post.html', {'post': post})
-    
+
 ```
 
 以訪客瀏覽 `http://127.0.0.1:8000/post/3/` 的例子，來解釋以上程式：
@@ -108,9 +108,9 @@ return render(request, 'post.html', {'post': post})
 <head>
     <meta charset="utf-8">
     <title>{{ post.title }} | A Django Girl’s Adventure</title>
-    <link href="//fonts.googleapis.com/css?family=Lemon" rel="stylesheet" type="text/css">
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="//djangogirlstaipei.github.io/assets/css/style.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lemon" rel="stylesheet" type="text/css">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="https://djangogirlstaipei.github.io/assets/css/style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div class="header">
@@ -132,15 +132,17 @@ return render(request, 'post.html', {'post': post})
             {{ post.content }}
         </div>
         <hr class="fancy-line">
+        {% if post.photo %}
         <img class="photo" src="{{ post.photo }}" alt="Cover photo for {{ post.title }}">
+        {% endif %}
     </div>
-    <script src="//maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&sensor=false"></script>
-    <script src="//djangogirlstaipei.github.io/assets/js/map.js"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&sensor=false"></script>
+    <script src="https://djangogirlstaipei.github.io/assets/js/map.js"></script>
 </body>
 </html>
 ```
 
-這個 template 將 post 物件的屬性 (e.g. 標題、內文、時間......等)，利用 `{{ var }}` 與 template filter 顯示並格式化於 HTML 中。若資料庫裡有 pk=3 的 Post，現在連至 <http://127.0.0.1:8000/post/3/> 即可看到此日記的單頁。
+這個 template 將 post 物件的屬性 (標題、內文、時間等等)，利用 `{{ var }}` 與 template filter 顯示並格式化於 HTML 中。若資料庫裡有 pk=3 的 Post，現在連至 <http://127.0.0.1:8000/post/3/> 即可看到此日記的單頁。
 
 ---
 
@@ -160,7 +162,7 @@ return render(request, 'post.html', {'post': post})
 {% url '<url_name>' arg1=<var1> arg2=<var2> ...%}
 ```
 
-其餘用法可參考[官方文件](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#url)。
+其餘用法可參考[官方文件](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#url)。
 
 ---
 

--- a/django/installation.md
+++ b/django/installation.md
@@ -35,23 +35,20 @@ cd djangogirls
 
 在較舊的 Python 版本中，建立處擬環境需要另外安裝。但 Python 3.3 之後已經加入 `venv` 模組，可以直接使用。
 
-那我們立刻開始，首先要創建一個虛擬環境資料夾 `djangogirls_venv`。
-
-#### Windows
-
-如果有按照安裝教學，使用 **Django Environment** 開啟終端機後，輸入以下指令：
-
-    C:\Users\YOUR_NAME\djangogirls> python -m venv djangogirls_venv
-
-#### Linux / OS X
-
-Linux 或 OS X 需要使用 `python3` 來建立虛擬環境，指令如下：
+首先要創建一個虛擬環境資料夾 `djangogirls_venv`。如果你是按照我們的[安裝教學](https://djangogirlstaipei.herokuapp.com/tutorials/installation/)設定開發環境，可以開啟終端機，輸入以下指令：
 
 ```
 ~/djangogirls$ python3 -m venv djangogirls_venv
 ```
 
+若你使用 Windows，且沒有使用安裝教學設定 Python，則可能需要使用 `python` 指令，而非 `python3`：
+
+```
+C:\Users\YOUR_NAME\djangogirls> python -m venv djangogirls_venv
+```
+
 ### 切換虛擬環境
+
 虛擬環境建立完成後，我們可以透過 `activate` 這個 script 來啟動它。
 
 記得未來在安裝新套件，或是要執行 Django 相關指令時，都要先啟動該專案的虛擬環境。
@@ -60,11 +57,11 @@ Linux 或 OS X 需要使用 `python3` 來建立虛擬環境，指令如下：
 
     C:\Users\YOUR_NAME\djangogirls> djangogirls_venv\Scripts\activate
 
-#### Linux / OS X
+#### Linux / macOS
 
     ~/djangogirls$ source djangogirls_venv/bin/activate
 
-如果無法使用 `source` 的話，可以用下列指令替代：
+如果無法使用 `source`，可以試著用 `.` 替代：
 
     ~/djangogirls$ . djangogirls_venv/bin/activate
 
@@ -77,31 +74,31 @@ Linux 或 OS X 需要使用 `python3` 來建立虛擬環境，指令如下：
 
     (djangogirls_venv) C:\Users\YOUR_NAME\djangogirls>
 
-#### Linux / OS X
+#### Linux / macOS
 
     (djangogirls_venv) ~/djangogirls$
 
 
-## 安裝 Django 1.8 最新版本
+## 安裝 Django 1.11 最新版本
 
 ### 開始安裝
 
-Python 3.4 預先安裝了 `pip` 這個強大的套件管理工具，我們將使用它來安裝 Django：
+Python 提供了 `pip` 這個強大的套件管理工具，我們將使用它來安裝 Django：
 
 ```
-(djangogirls_venv) ~/djangogirls$ pip install "django<1.9"
+(djangogirls_venv) ~/djangogirls$ pip install "django<1.12"
 ```
 
-這裡需要特別注意，我們使用的指令是 `"django`**`<1.9`**`"`。這樣一來才可以**確保我們安裝的是 Django 1.8 的最新版本**
+這裡需要特別注意，我們使用的指令是 "django**<1.12**"。這樣一來才可以確保安裝 **Django 1.11 的最新版本**。
 
 輸入了應該會看到如下的訊息，表示安裝成功
 
 ```
-Installing collected packages: django
-Successfully installed django-1.8.6
+Installing collected packages: pytz, django
+Successfully installed django-1.11.2 pytz-2017.2
 ```
 
-註：如果你看到以 *Fatal error in launcher* 開頭的輸出，而不是上面的安裝成功訊息，請改用 `python -m pip install "django<1.9"` 試試看。之後如果在使用 `pip` 時遇到類似問題，也可以試著在前面加上 `python -m`。
+註：如果你看到以 *Fatal error in launcher* 開頭的輸出，而不是上面的安裝成功訊息，請改用 `python -m pip install "django<1.12"` 試試看。之後如果在使用 `pip` 時遇到類似問題，也可以試著在前面加上 `python -m`。
 
 
 ### 確認安裝成功
@@ -119,7 +116,7 @@ Successfully installed django-1.8.6
 ```
 >>> import django
 >>> django.VERSION
-(1, 8, 6, 'final, 0')
+(1, 11, 2, 'final, 0')
 ```
 
 如果看見類似上面的訊息，就代表安裝成功囉！

--- a/django/models.md
+++ b/django/models.md
@@ -34,9 +34,10 @@ DATABASES = {
 在這裡我們設定了資料庫連線的預設值：
 
 - **ENGINE** -- 你要使用的資料庫引擎。例如：
+    - PostgreSQL: `django.db.backends.postgresql`
     - MySQL: `django.db.backends.mysql`
     - SQLite 3: `django.db.backends.sqlite3`
-    - PostgreSQL: `django.db.backends.postgresql_psycopg2`
+    - Oracle: 'django.db.backends.oracle'
 - **NAME** -- 你的資料庫名稱
 
 如果你使用 MySQL 或 PostgreSQL 等等資料庫，可能還要設定它的位置、名稱、使用者等等。不過我們這裡使用的 SQLite 3 不需要這些性質，所以可以省略。
@@ -58,7 +59,6 @@ class Post(models.Model):
     photo = models.URLField(blank=True)
     location = models.CharField(max_length=100)
     created_at = models.DateTimeField(auto_now_add=True)
-
 ```
 
 - Django 預設會為每一個 Model 加上 `id` 欄位，並將這個欄位設成 primary key（主鍵），簡稱 **pk**，讓每一筆資料都會有一個獨一無二的 ID。
@@ -82,7 +82,7 @@ class Post(models.Model):
 - **URLField** -- **URL 設計的欄位**
 - **DateTimeField** -- **日期與時間的欄位**，使用時會轉成 Python `datetime` 型別。
 
-更多 Model Field 與其參數，請參考 [Django 文件 ](https://docs.djangoproject.com/en/1.8/ref/models/fields/)
+更多 Model Field 與其參數，請參考 [Django 文件 ](https://docs.djangoproject.com/en/1.11/ref/models/fields/)
 
 ---
 
@@ -93,11 +93,11 @@ class Post(models.Model):
 ```
 (djangogirls_venv) ~/djangogirls/mysite$ python manage.py makemigrations
 Migrations for 'trips':
-  0001_initial.py:
+  trips/migrations/0001_initial.py
     - Create model Post
 ```
 
-這個指令會根據你對 Model 的修改刪除建立一個新的 [migration 檔案](https://docs.djangoproject.com/en/1.8/topics/migrations/#migration-files)，讓 `migrate` 指令執行時，可以照著這份紀錄更新資料庫。
+這個指令會根據你對 Model 的修改刪除建立一個新的 [migration 檔案](https://docs.djangoproject.com/en/1.11/topics/migrations/#migration-files)，讓 `migrate` 指令執行時，可以照著這份紀錄更新資料庫。
 
 接著用以下的指令，讓 Django 根據上面的紀錄，把 `models.py` 中的欄位寫入資料庫：
 
@@ -109,25 +109,9 @@ Migrations for 'trips':
 
 ```
 Operations to perform:
-  Synchronize unmigrated apps: staticfiles, messages
-  Apply all migrations: sessions, admin, auth, contenttypes
-Synchronizing apps without migrations:
-  Creating tables...
-    Running deferred SQL...
-  Installing custom SQL...
+  Apply all migrations: admin, auth, contenttypes, sessions, trips
 Running migrations:
-  Rendering model states... DONE
-  Applying contenttypes.0001_initial... OK
-  Applying auth.0001_initial... OK
-  Applying admin.0001_initial... OK
-  Applying contenttypes.0002_remove_content_type_name... OK
-  Applying auth.0002_alter_permission_name_max_length... OK
-  Applying auth.0003_alter_user_email_max_length... OK
-  Applying auth.0004_alter_user_username_opts... OK
-  Applying auth.0005_alter_user_last_login_null... OK
-  Applying auth.0006_require_contenttypes_0002... OK
-  Applying sessions.0001_initial... OK
   Applying trips.0001_initial... OK
 ```
 
-[`migrate`](https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-migrate) 指令會根據 `INSTALLED_APPS` 的設定，按照 app 順序建立或更新資料表，將你在 models.py 裡的更新跟資料庫同步。
+[`migrate`](https://docs.djangoproject.com/en/1.11/ref/django-admin/#django-admin-migrate) 指令會根據 `INSTALLED_APPS` 的設定，按照 app 順序建立或更新資料表，將你在 models.py 裡的更新跟資料庫同步。

--- a/django/next.md
+++ b/django/next.md
@@ -7,18 +7,18 @@
 
 - 修改 HTML 與 CSS，調整成你喜歡的樣子
 - 為旅遊日記添加新的欄位（例如旅遊日期），並使用 `makemigrations` 和 `migrate` 更新資料庫。
-- 為旅遊日記加入作者（提示：你可能會需要修改 Model，並與 [Django 使用者認證](https://docs.djangoproject.com/en/1.7/topics/auth/) 功能整合）
-- 將 HTML 重複的部分獨立出來共用（提示：使用 [Template 繼承](https://docs.djangoproject.com/en/1.7/topics/templates/#template-inheritance)）
-- 為每一篇日記加上留言板（提示：[ Django Forms](https://docs.djangoproject.com/en/dev/topics/forms/) 可以幫助你更快速地完成）
+- 為旅遊日記加入作者（提示：你可能會需要修改 Model，並與 [Django 使用者認證](https://docs.djangoproject.com/en/1.11/topics/auth/) 功能整合）
+- 將 HTML 重複的部分獨立出來共用（提示：使用 [Template 繼承](https://docs.djangoproject.com/en/1.11/topics/templates/#template-inheritance)）
+- 為每一篇日記加上留言板（提示：[Django Forms](https://docs.djangoproject.com/en/1.11/topics/forms/) 可以幫助你更快速地完成）
 
 
 ## 其他學習資源
 
 - [Codecademy](http://www.codecademy.com/learn) -- 透過闖關遊戲方式學習 Python, HTML/CSS, JavaScript
-- [Writing your first Django app](https://docs.djangoproject.com/en/1.8/intro/tutorial01/) -- Django 1.8 官方學習指南
+- [Writing your first Django app](https://docs.djangoproject.com/en/1.11/intro/tutorial01/) -- Django 1.8 官方學習指南
 - [Getting Started With Django](http://gettingstartedwithdjango.com/) -- 影片課程
-- [The Django Book](https://django-book.readthedocs.org/en/latest/) -- 雖然 Django 版本不是最新，但相當適合初學者的一本書
-- [Two Scoops of Django: Best Practices for Django](http://twoscoopspress.org/products/two-scoops-of-django-1-8) -- 非常推薦，曾經在 [Taipei.py](http://www.meetup.com/Taipei-py/) 隔週二聚會指定書籍
+- [The Django Book](http://djangobook.com/the-django-book/) -- 相當適合初學者的一本書。目前正在將教材逐步更新到 1.11，內容仍然略有缺漏，但仍然是很好的教材。
+- [Two Scoops of Django: Best Practices for Django 1.11](https://www.twoscoopspress.com/products/two-scoops-of-django-1-11) -- 非常推薦。[1.8 版](https://www.twoscoopspress.com/products/two-scoops-of-django-1-8)曾經在 [Taipei.py](http://www.meetup.com/Taipei-py/) 隔週二聚會指定書籍
 - [Django Packages](https://www.djangopackages.com/) -- Django 相關套件彙整平台，提供搜尋和評比
 
 ---

--- a/django/orm.md
+++ b/django/orm.md
@@ -16,7 +16,7 @@
 
 在練習之前，我們先來安裝一個「加強版」的 Python shell：**IPython**。
 
-[IPython](http://ipython.org/) 是強化版的 Python 互動式命令列介面，它比預設的命令列介面多了許多進階功能，例如：
+[IPython](https://ipython.org/) 是強化版的 Python 互動式命令列介面，它比預設的命令列介面多了許多進階功能，例如：
 
 - 按 tab 鍵可以補齊未輸入完的指令、檔案及資料夾名稱。
 - 按 ↑ 鍵和 ↓ 鍵可以瀏覽輸入過的程式碼，便於微調先前的程式碼（修改參數等等）。
@@ -30,7 +30,7 @@
 (djangogirls_venv) ~/djangogirls/mysite$ pip install ipython[terminal]
 ```
 
-安裝完畢後，就可以使用 [shell](https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-shell) 指令，進入 Django Shell：
+安裝完畢後，就可以使用 [shell](https://docs.djangoproject.com/en/1.11/ref/django-admin/#django-admin-shell) 指令，進入 Django Shell：
 
 ```
 (djangogirls_venv) ~/djangogirls/mysite$ python manage.py shell
@@ -43,7 +43,7 @@
 
 ### Create
 
-首先，讓我們來試著新增幾筆資料：
+首先，讓我們來試著新增幾筆資料。在新增的同時，也可以用上一章提到的 admin 介面，當你新增資料，然後重新整理頁面，真的會多一行一行增加！
 
 ```
 >>> from trips.models import Post
@@ -61,12 +61,12 @@
 ### Read
 
 若想顯示所有的 Post ，可以使用
-[all()](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.query.QuerySet.all)：
+[all()](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#django.db.models.query.QuerySet.all)：
 
 ```
 >>> from trips.models import Post
 >>> Post.objects.all()
-[<Post: My First Trip>, <Post: My Second Trip>, <Post: Django 大冒險>]
+<QuerySet [<Post: My First Trip>, <Post: My Second Trip>, <Post: Django 大冒險>]>
 ```
 
 只想顯示部分資料時，則可以使用 `get` 或 `filter`：
@@ -76,19 +76,19 @@
 <Post: My First Trip>
 
 >>> Post.objects.filter(location__contains='台北')
-[<Post: My First Trip>, <Post: Django 大冒險>]
+<QuerySet [<Post: My First Trip>, <Post: Django 大冒險>]>
 ```
 
-- [**get**](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#get)：返回符合條件的**唯一一筆資料**。（*注意：*如果找不到符合條件的資料、或是有多筆資料符合條件，都會產生 exception）
+- [**get**](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#get)：返回符合條件的**唯一一筆資料**。（*注意：*如果找不到符合條件的資料、或是有多筆資料符合條件，都會產生 exception）
 
-- [**filter**](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#filter)：返回符合條件的陣列。如果找不到任何資料則會返回空陣列。
+- [**filter**](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#filter)：返回符合條件的陣列。如果找不到任何資料則會返回空陣列。
 
 
 ### Update
 
-當想修改資料時，可以使用 [update](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.query.QuerySet.update) 更新一筆或多筆資料：
+當想修改資料時，可以使用 [update](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#django.db.models.query.QuerySet.update) 更新一筆或多筆資料：
 
-首先，這裡使用 [contains](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#contains) 針對`title`欄位，篩選出所有標題中包含 `Trip` 字眼的 Post
+首先，這裡使用 [contains](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#contains) 針對`title`欄位，篩選出所有標題中包含 `Trip` 字眼的 Post
 
 ```
 >>> posts = Post.objects.filter(title__contains='Trip')
@@ -105,7 +105,7 @@
 
 ```
 >>> posts
-[<Post: My First Trip>, <Post: My Second Trip>]
+<QuerySet [<Post: My First Trip>, <Post: My Second Trip>]>
 ```
 
 我們將 location 的值印出
@@ -138,17 +138,18 @@
 
 ### Delete
 
-我們也可以使用 [delete](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.query.QuerySet.delete) 刪除資料：
+我們也可以使用 [delete](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#django.db.models.query.QuerySet.delete) 刪除資料：
 
 我們試著使用 `delete`，將剛剛的那兩筆 Post 刪除。
 
 ```
 >>> posts.delete()
+(2, {'trips.Post': 2})
 ```
 
 最後確認一下，資料是否刪除
 
 ```
 >>> Post.objects.all()
-[<Post: Django 大冒險>]
+<QuerySet [<Post: Django 大冒險>]>
 ```

--- a/django/project_and_app.md
+++ b/django/project_and_app.md
@@ -1,15 +1,15 @@
 # Project and apps
 
-每一個 Django project 裡面可以有多個 Django apps，可以想成是類似模組的概念。在實務上，**通常會依功能分成不同 app**，方便未來的維護和重複使用。
+每一個 Django project 裡面可以有多個 Django apps，可以想成是類似模組的概念。在實務上，通常會依功能分成不同 app，方便未來的維護和重複使用。
 
 例如，我們要做一個類似 Facebook 這種網站時，依功能可能會有以下 apps：
 
-- 使用者管理 -- accounts
-- 好友管理 -- friends
-- 塗鴉牆管理 -- timeline
-- 動態消息管理 -- news
+- 使用者管理 — accounts
+- 好友管理 — friends
+- 塗鴉牆管理 — timeline
+- 動態消息管理 — news
 
-若未來我們需要寫個購物網站，而需要會員功能時，`accounts` app（使用者管理）就可以被重複使用。
+則將來如果我們需要寫個購物網站，而需要會員功能時，`accounts` app（使用者管理）就可以被重複使用。
 
 ---
 
@@ -19,8 +19,9 @@
 
 ## 建立 Django project
 
-### 建立專案資料夾 -- startproject
-首先，使用 `django-admin.py` 來建立第一個 Django project `mysite`:
+### 建立專案資料夾 — `startproject`
+
+使用 `django-admin.py` 來建立第一個 Django project `mysite`:
 
 ```
 (djangogirls_venv) ~/djangogirls$ django-admin.py startproject mysite
@@ -47,7 +48,7 @@ mysite/
 ```
 
 
-### 瞭解 Django 的 Management commands
+### 瞭解 Django 的 management commands
 
 `manage.py` 是 Django 提供的命令列工具，我們可以利用它執行很多工作，例如同步資料庫、建立 app 等等，指令的使用方式如下：
 
@@ -55,16 +56,16 @@ mysite/
 python manage.py <command> [options]
 ```
 
-如果你想要了解有什麼指令可以使用，輸入 `help` 或 `-h` 指令會列出所有指令列表:
+如果你想要了解有什麼指令可以使用，輸入 `help`、`--help` 或 `-h` 指令會列出所有指令列表:
 
 ```
-python manage.py -h
+python manage.py help
 ```
 
-而如果想了解其中一個指令，可以在指令名字後輸入 `-h`，你會看到簡單的的指令介紹以及用法說明。以 `runserver` 為例：
+而如果想了解其中一個指令，可以在指令名字後輸入 `--help`，你會看到簡單的的指令介紹以及用法說明。以 `runserver` 為例：
 
 ```
-(djangogirls_venv) ~/djangogirls/mysite$ python manage.py runserver -h
+(djangogirls_venv) ~/djangogirls/mysite$ python manage.py runserver --help
 usage: manage.py runserver [-h] [--version] [-v {0,1,2,3}]
                            [--settings SETTINGS] [--pythonpath PYTHONPATH]
                            [--traceback] [--no-color] [--ipv6] [--nothreading]
@@ -99,14 +100,46 @@ optional arguments:
   --insecure            Allows serving static files even if DEBUG is False.
 ```
 
-### 啟動開發伺服器 -- `runserver`
+### 資料庫初始化 — `migrate`
+
+為了讓你的網站儲存資料，Django 會把一些資料儲存在資料庫裡。使用 `migrate` 指令，為 Django 建立必要的資料格式：
+
+```
+(djangogirls_venv) ~/djangogirls/mysite$ python manage.py migrate
+```
+
+應該會得到類似下面的效果：
+
+```
+Operations to perform:
+  Apply all migrations: admin, auth, contenttypes, sessions
+Running migrations:
+  Applying contenttypes.0001_initial... OK
+  Applying auth.0001_initial... OK
+  Applying admin.0001_initial... OK
+  Applying admin.0002_logentry_remove_auto_add... OK
+  Applying contenttypes.0002_remove_content_type_name... OK
+  Applying auth.0002_alter_permission_name_max_length... OK
+  Applying auth.0003_alter_user_email_max_length... OK
+  Applying auth.0004_alter_user_username_opts... OK
+  Applying auth.0005_alter_user_last_login_null... OK
+  Applying auth.0006_require_contenttypes_0002... OK
+  Applying auth.0007_alter_validators_add_error_messages... OK
+  Applying auth.0008_alter_user_username_max_length... OK
+  Applying sessions.0001_initial... OK
+```
+
+我們會在 **Django Models** 這章詳細解釋資料庫、Django 使用資料庫的方法、以及 `migrate` 指令。
+
+
+### 啟動開發伺服器 — `runserver`
 
 從說明中可以知道，`runserver` 會啟動一個簡單的 web server，方便於在開發階段使用：
 
 ```
 (djangogirls_venv) ~/djangogirls/mysite$ python manage.py runserver
 ...
-Django version 1.8.5, using settings 'mysite.settings'
+Django version 1.11.2, using settings 'mysite.settings'
 Starting development server at http://127.0.0.1:8000/
 Quit the server with CONTROL-C.
 ```
@@ -115,21 +148,8 @@ Quit the server with CONTROL-C.
 
 ![Django startproject success](./../images/django-startproject-success.png)
 
-
 最後我們可以在終端機按下 `CTRL+C` ，關閉 web server 回到命令列。
 
-
----
-
-如果無法看到成功畫面，瀏覽器上顯示錯誤訊息 - *A server error occurred.  Please contact the administrator.*，請輸入：
-
-```
-(djangogirls_venv) ~/djangogirls/mysite$ python manage.py migrate
-```
-
-然後再次 `runserver` 啟動你的 web server，我們會在 **Django Models** 解釋 `migrate` 的作用。
-
----
 
 ## 建立 Django application（app）
 
@@ -157,7 +177,7 @@ trips
 
 ##新增 app
 
-打開 *mysite/settings.py*，找到 [INSTALLED_APPS](https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-INSTALLED_APPS)，調整如下：
+打開 *mysite/settings.py*，找到 [INSTALLED_APPS](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-INSTALLED_APPS)，調整如下：
 
 ```
 # mysite/settings.py
@@ -166,7 +186,7 @@ trips
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -174,7 +194,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'trips',
-)
+]
 ```
 
 請注意 app 之間有時候需要特定先後順序。在此，我們將自訂的 `trips` 加在最後面。
@@ -215,7 +235,8 @@ mysite
 | 指令 | 說明 |
 | ---|--- |
 | django-admin.py **startproject** *`<project_name>`* | 建立 Django 專案 |
-| python manage.py **-h** *`<command_name>`* | 查看 Django commands 的使用方法 |
+| python manage.py *`<command_name>`* **--help** | 查看 Django commands 的使用方法 |
+| python manage.py **migrate** | 為 Django 設定資料庫 |
 | python manage.py **runserver** | 啟動開發伺服器 |
 | python manage.py **startapp** *`<app_name>`*  | 新增 Django app |
 

--- a/django/template_tags.md
+++ b/django/template_tags.md
@@ -6,7 +6,7 @@
 - **重覆 HTML 片段** (for loop) -- 列出所有好友的帳號和顯示圖片
 - **格式化 Template 中的變數** -- 日期的格式化等等
 
-[Django template tags](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/) 讓你可以在 HTML 檔案裡使用類似 Python 的語法，動態存取從 view function 傳過來的變數，或是在顯示到瀏覽器之前幫你做簡單的資料判斷、轉換、計算等等。
+[Django template tags](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/) 讓你可以在 HTML 檔案裡使用類似 Python 的語法，動態存取從 view function 傳過來的變數，或是在顯示到瀏覽器之前幫你做簡單的資料判斷、轉換、計算等等。
 
 ---
 
@@ -85,13 +85,13 @@ urlpatterns = [
 
 ### 顯示 Post 中的資料
 
-仔細觀察印出的 `post_list`，會發現是以 list 的形式顯示。但我們希望的則是：**存取每個 Post 中的資料，並印出來**。
+現在我們印出的 `post_list` 是一個 QuerySet，但我們希望的其實是**存取每個 Post 中的資料，並按照我們想要的格式印出來**。
 
 為了達成這個功能，我們會用到 `for` 這個 template tag。
 
 #### `for` 迴圈
 
-在寫 Python 時，若想存取 list 裡的每一個元素，我們會使用 `for` 迴圈。而在 Django Template 中，也提供了類似的 template tags -- [{% raw %}{% for %}{% endraw %}](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#for)。
+在寫 Python 時，若想存取 list 裡的每一個元素，我們會使用 `for` 迴圈。而在 Django Template 中，也提供了類似的 template tags -- [{% raw %}{% for %}{% endraw %}](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#for)。
 
 ---
 
@@ -113,12 +113,12 @@ urlpatterns = [
 <!-- home.html -->
 
 {% for post in post_list %}
-    <div>
+<div>
     {{ post.title }}
     {{ post.created_at }}
     {{ post.photo }}
     {{ post.content }}
-    </div>
+</div>
 {% endfor %}
 ```
 - 開始標籤為 `{% raw %}{% for %}{% endraw %}` 開始；結束標籤為 `{% raw %}{% endfor %}{% endraw %}`
@@ -143,7 +143,7 @@ urlpatterns = [
 
 ```html
 <div class="thumbnail">
-    <img src="{{ post.photo }}" alt="">
+    <img src="{{ post.photo }}" alt="{{ post.title }}">
 </div>
 ```
 
@@ -151,28 +151,28 @@ urlpatterns = [
 
 #### `if`…`else`
 
-另一個常用的 template tags 是 [{% raw %}{% if %}{% endraw %}](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#if) 判斷式，用法如下：
+另一個常用的 template tags 是 [{% raw %}{% if %}{% endraw %}](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#if) 判斷式，用法如下：
 
 ```html
-{% if post.photo %}
 <div class="thumbnail">
-    <img src="{{ post.photo }}" alt="">
+    {% if post.photo %}
+    <img src="{{ post.photo }}" alt="Cover photo for {{ post.title }}">
+    {% else %}
+    <img src="https://placeholder.com/800x600" alt="No image">
+    {% endif %}
 </div>
-{% else %}
-<div class="thumbnail thumbnail-default"></div>
-{% endif %}
 ```
 
 - 符合條件所想要顯示的 HTML 放在 `{% raw %}{% if `*`<condition>`*` %}{% endraw %}` 區塊裡
 - 不符合的則放在 `{% raw %}{% else %}{% endraw %}` 區塊裡面
 - 最後跟 **for** 一樣，要加上 `{% raw %}{% endif %}{% endraw %}` 作為判斷式結尾。
 
-在這裡，我們判斷如果 `post.photo` 有值就顯示照片，否則就多加上一個 CSS class `photo-default` 另外處理。
+在這裡，我們判斷如果 `post.photo` 有值就顯示照片，否則使用 https://placeholder.com 這個服務，產生一張空白的圖片，讓版面一致。我們把這種沒有實際意義的內容叫做 placeholder，也就是這個服務的名稱。
 
 
 ## Template Filter
 
-除了 template tags ，Django 也內建也許多好用的 [template filters](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#built-in-filter-reference)。它能在變數顯示之前幫你做計算、設定預設值，置中、或是截斷過長的內容等等。使用方法如下:
+除了 template tags ，Django 也內建也許多好用的 [template filters](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#built-in-filter-reference)。它能在變數顯示之前幫你做計算、設定預設值，置中、或是截斷過長的內容等等。使用方法如下:
 
 `{{<variable_name>|<filter_name>:<filter_arguments>}}`
 
@@ -182,12 +182,12 @@ urlpatterns = [
 
 #### 變更時間的顯示格式
 
-在這裡，我們只練習一種很常用的 filter [date](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#date)。它可以將 `datetime` 型別的物件，以指定的時間格式輸出。
+在這裡，我們只練習一種很常用的 filter [date](https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#date)。它可以將 `datetime` 型別的物件，以指定的時間格式輸出。
 
 我們試著將 `created_at` 時間顯示成**年 / 月 / 日**：
 
 ```html
-{{ post.created_at|date:"Y / m / d" }}
+{{ post.created_at|date:'Y / m / d' }}
 ```
 ---
 
@@ -205,9 +205,9 @@ urlpatterns = [
 <head>
     <meta charset="utf-8">
     <title>A Django Girl's Adventure</title>
-    <link href="//fonts.googleapis.com/css?family=Lemon" rel="stylesheet" type="text/css">
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="//djangogirlstaipei.github.io/assets/css/style.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lemon" rel="stylesheet" type="text/css">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="https://djangogirlstaipei.github.io/assets/css/style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div class="header">
@@ -223,15 +223,15 @@ urlpatterns = [
                     <h2 class="title">
                         <a href="#">{{ post.title }}</a>
                     </h2>
-                    <div class="date">{{ post.created_at|date:"Y / m / d" }}</div>
+                    <div class="date">{{ post.created_at|date:'Y / m / d' }}</div>
                 </div>
-                {% if post.photo %}
                 <div class="thumbnail">
-                    <img src="{{ post.photo }}" alt="">
+                    {% if post.photo %}
+                    <img src="{{ post.photo }}" alt="Cover photo for {{ post.title }}">
+                    {% else %}
+                    <img src="https://placeholder.com/800x600" alt="No image">
+                    {% endif %}
                 </div>
-                {% else %}
-                <div class="thumbnail thumbnail-default"></div>
-                {% endif %}
                 <div class="post-content read-more-block">
                     {{ post.content }}
                 </div>
@@ -269,6 +269,3 @@ urlpatterns = [
 <tr><th>語法</th><th>說明</th></tr>
 <tr><td>{% raw %}{{{% endraw %} value<strong>|date:</strong><i>&lt;date_format&gt;</i> {% raw %}}}{% endraw %} </td><td>可以將`datetime`型別的物件，以指定的時間格式 Date Format 輸出</td></tr>
 </table>
-
-
-

--- a/django/templates.md
+++ b/django/templates.md
@@ -27,7 +27,7 @@
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates').replace('\\', '/')],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -44,7 +44,7 @@ TEMPLATES = [
 我們將 `'DIRS'` 原本的`[]`修改成：
 
 ```python
-[os.path.join(BASE_DIR, 'templates').replace('\\', '/')]
+[os.path.join(BASE_DIR, 'templates')]
 ```
 
 好讓 Django 找得到剛剛建立的 `templates` 資料夾。
@@ -92,13 +92,15 @@ mysite
 
 以上 Template 中，有個地方要特別注意：
 
-    <em>{{ current_time }}</em>
+```html
+<em>{{ current_time }}</em>
+```
 
 在 Template 裡面．我們會使用兩個大括號，來顯示變數`current_time`。
 
 ---
 
-`{{`*`<variable_name>`*`}}` 是在 Django Template 中顯示變數的語法。
+`{{ <variable_name> }}` 是在 Django Template 中顯示變數的語法。
 
 其它 Django Template 語法，我們會在後面的章節陸續練習到。
 
@@ -138,7 +140,7 @@ def hello_world(request):
 
 `render`：產生 HttpResponse 物件。
 
-[render(request, template_name, dictionary)](https://docs.djangoproject.com/en/1.8/topics/http/shortcuts/#render)
+[render(request, template_name, dictionary)](https://docs.djangoproject.com/en/1.11/topics/http/shortcuts/#render)
 
 ---
 

--- a/django/views_and_urlconfs.md
+++ b/django/views_and_urlconfs.md
@@ -19,10 +19,10 @@
 
 Django view 其實是一個 function，**處理 `HttpRequest` 物件，並回傳 `HttpResponse` 物件**，大致說明如下：
 
-- **會收到 `HttpRequest` 參數：** Django 從網頁接收到 request 後，會將 request 中的資訊封裝產生一個 [HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#httprequest-objects) 物件，並當成第一個參數，傳入對應的 view function。
+- **會收到 `HttpRequest` 參數：** Django 從網頁接收到 request 後，會將 request 中的資訊封裝產生一個 [HttpRequest](https://docs.djangoproject.com/en/1.11/ref/request-response/#httprequest-objects) 物件，並當成第一個參數，傳入對應的 view function。
 
 - **需要回傳 `HttpResponse` 物件：**
-[HttpResponse](https://docs.djangoproject.com/en/1.8/ref/request-response/#httpresponse-objects) 物件裡面包含：
+[HttpResponse](https://docs.djangoproject.com/en/1.11/ref/request-response/#httpresponse-objects) 物件裡面包含：
     - `HttpResponse.content`
     - `HttpResponse.status_code` …等
 
@@ -88,14 +88,15 @@ url(r'^hello/$', hello_world),
 ```python
 # mysite/urls.py
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
-# Import view functions from trips app.
+
 from trips.views import hello_world
 
+
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
     url(r'^hello/$', hello_world),
+    url(r'^admin/', admin.site.urls),
 ]
 ```
 


### PR DESCRIPTION
主要的修改：

* 所有官網連結更新到 1.11
* `INSTALLED_APPS` 現在改成 list 了
* Database backend 裡 PostgreSQL 的路徑有變
* `url(r'^admin/', admin.site.urls)` 現在不用 `include()`
* QuerySet 的 repr 長得不太一樣
* `Queryset.delete()` 現在有 return value
* Deploy 之前需要在 `ALLOWED_HOSTS` 新增值
* 所有 static file 連結都改用 `https://` 而不是 `//`
* The Django Book 現在有在更新了所以稍微調整介紹文字。Two Scoops of Django 有 1.11 版所以同樣處理。
* 把昨天討論的幾個點直接加進去
    * 拿掉 template root 的 `replace()`
    * 在講 ORM 時可以同時看 admin 有在更新
    * 讓後續 deploy 的步驟更清楚
    * 改用 placeholder.com，然後把 `<img>` tags 都加上 `alt` attribute

還需要做的事情：

* 所有 admin 畫面重新截圖
* Template tags 有一張顯示 QuerySet repr 的圖也需要重截

需要討論：

* 要直接讓他們 `ALLOWED_HOSTS = ['*']`，還是要解釋它的用意，然後只放必要的網址（目前的做法）？
* 我改成先 migrate 再第一次 runserver，因為現在直接跑會噴一些看起來很可怕的警告（雖然無害）。有必要嗎？
